### PR TITLE
Tweaks

### DIFF
--- a/test/screens/home.screen.js
+++ b/test/screens/home.screen.js
@@ -1,11 +1,11 @@
 class homeScreen {
 
-    get enterFormsAddress() {
-        return $('~Forms')
+    async goToForms() {
+        await $('~Forms').click()
     }
 
-    async goToForms() {
-        await this.enterFormsAddress.click()
+    async goToLogin() {
+        await $('~Login').click()
     }
 }
 

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -3,19 +3,24 @@ const {join} = require('path')
 exports.config = {
     hostname: '127.0.0.1',
     port: 4723,
-    path: '/wd/hub',
+    // o path do Appium a partir do 2.0 não é mais /wd/hub, mas sim só /
+    path: '/',
     specs: [
         './test/specs/**/*.spec.js'
     ],
     framework: 'mocha',
     capabilities: [{
+        // algumas desired capabilites precisam do vendor prefix antes (i.e., appium:)
+        // https://appium.io/docs/en/2.1/guides/caps/
         "platformName": "Android",
-        "platformVersion": "13.0",
-        "deviceName": "ebac-qe",
-        "automationName": "UiAutomator2",
-        "app": join(process.cwd(), './app/android/Android-NativeDemoApp-0.4.0.apk'),
-        "appPackage": "com.wdiodemoapp",
-        "appWaitActivity": 'com.wdiodemoapp.MainActivity',
-        "appWaitActivity": "com.wdiodemoapp.SpashActivitty"
+        "appium:platformVersion": "12",
+        // aqui eu recomendo você dar uma olhada no UDID do seu aparelho
+        // https://www.bestinterviewquestion.com/question/what-is-udid-and-how-do-you-find-udid-in-appium-gmgte5343x9
+        // o nome do seu device com certeza não é esse - esse é o do professor, mas aparentemente ele não explicou isso direito
+        "appium:deviceName": "pixel2",
+        "appium:automationName": "uiautomator2",
+        "appium:app": join(process.cwd(), './app/android/Android-NativeDemoApp-0.4.0.apk'),
+        "appium:packageName": "com.wdiodemoapp",
+        "appium:appWaitActivity": 'MainActivity'
     }]
 }


### PR DESCRIPTION
Alterações para funcionamento:

- Desde que estamos usando o Appium 2.0, o padrão do path não é mais `/wd/hub`, e sim `/`;
- É indispensável utilizar os _vendor prefixes_ quando usar as _desired capabilities_ do Appium (mais informação em: [Appium - Caps](https://appium.readthedocs.io/en/stable/en/writing-running-appium/caps/);
- Acho que sem querer eu acabei deixando o meu `deviceName` e `platformVersion`. Antes de rodar a sua versão, por favor modificar para o seu dispositivo!;
- O método `enterFormsAddress` era redundante. Talvez colocar os localizadores em um arquivo de `Pages` e importar pra esse arquivo de `Screens`, sendo um para localizadores de elementos e outro para métodos, respectivamente;
- Adicionei o método `goToLogin()` porque o teste estava falhando sem ele.